### PR TITLE
Add model_type parameter to argument parser

### DIFF
--- a/models/initialise_arguments.py
+++ b/models/initialise_arguments.py
@@ -8,6 +8,7 @@ def initialise_arguments():
 
     # general
     parser.add_argument('--dataset', default='eICU', type=str)
+    parser.add_argument('--model_type', default='tpc', type=str)
     parser.add_argument('-disable_cuda', action='store_true')
     parser.add_argument('-intermediate_reporting', action='store_true')
     parser.add_argument('--batch_size_test', default=32, type=int)


### PR DESCRIPTION
Without this, the vanilla command `python -m models.run_tpc` fails with this error:

```
'Config' object has no attribute 'model_type'
```